### PR TITLE
Fix #8 Docker 対応と Github Container Registry の対応

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ insert_final_newline = true
 trim_trailling_whitespace = true
 charset = utf-8
 
+[*.yml]
+indent_style = space
+indent_size = 2
+
 [*.py]
 indent_style = tab
 indent_size = 2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: build
+on:
+  branches:
+    - main
+  push:
+    tags: v*
+jobs:
+  docker:
+    name: build docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Login GitHub Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Get Git Tag
+        run: echo GIT_TAG=$(echo ${{ github.ref }} | sed -e "s#^refs/tags/v##g") >>$GITHUB_ENV
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: |
+            "ghcr.io/${{ github.repository_owner }}/r53update:${{ env.GIT_TAG }}"
+            "ghcr.io/${{ github.repository_owner }}/r53update:latest"
+
+      - name: Push Docker image
+        run: |
+          docker push "ghcr.io/${{ github.repository_owner }}/r53update:${{ env.GIT_TAG }}"
+          docker push "ghcr.io/${{ github.repository_owner }}/r53update:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Dockerfile
+FROM alpine:3.5
+MAINTAINER Takuya Sawada <takuya@tuntunkun.com>
+
+ARG AWS_ACCESS_KEY
+ARG AWS_SECRET_KEY
+ARG AWS_REGION
+
+ENV AWS_ACCESS_KEY_ID ${AWS_ACCESS_KEY}
+ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_KEY}
+ENV AWS_DEFAULT_REGION ${AWS_REGION}
+
+RUN apk --update add python py-pip \
+        && apk add --virtual .build-deps git gcc python-dev musl-dev linux-headers \
+
+	&& pip install --upgrade pip \
+        && pip install git+https://github.com/tuntunkun/r53update@develop \
+
+        && apk del --purge .build-deps \
+        && rm -rf /var/apk/cache/*
+
+ENTRYPOINT ["r53update"]


### PR DESCRIPTION
alpine linux ベースの軽量な Docker イメージを作成し、環境に依存せずにデプロイ可能にするため Github Container Registry に展開に対応。